### PR TITLE
Add wrappers for NvLink NVML functions

### DIFF
--- a/pynvml/nvml.py
+++ b/pynvml/nvml.py
@@ -1828,13 +1828,19 @@ def nvmlDeviceGetTopologyCommonAncestor(device1, device2):
     return c_level.value
 
 def nvmlDeviceFreezeNvLinkUtilizationCounter(device, link, counter, freeze):
-    """
+    """Freeze the NVLINK utilization counters.
+
     Freeze the NVLINK utilization counters. Both the receive and transmit
     counters are operated on by this function.
 
-    Note on the freeze parameter:
-        NVML_FEATURE_ENABLED(1) = freeze the receive and transmit counters
-        NVML_FEATURE_DISABLED(0) = unfreeze the receive and transmit counters
+    Args:
+        device: The identifier of the target device
+
+        link: Specifies the NvLink link to be queried (uint)
+
+        freeze: NVML_FEATURE_ENABLED(1) = freeze the rx and tx counters
+                NVML_FEATURE_DISABLED(0) = unfreeze the rx and tx counters
+
     """
     c_link = c_uint(link)
     c_counter = c_uint(counter)
@@ -1843,11 +1849,24 @@ def nvmlDeviceFreezeNvLinkUtilizationCounter(device, link, counter, freeze):
     return check_return(ret)
 
 def nvmlDeviceGetNvLinkCapability(device, link, cap):
-    """
+    """Retrieve the capability of a specified NvLinklink.
+
     Retrieves the requested capability from the device's NvLink for the link
     specified. Please refer to the nvmlNvLinkCapability_t structure for the
     specific caps that can be queried. The return value should be treated as a
     boolean.
+
+    Args:
+        device: The identifier of the target device
+
+        link: Specifies the NvLink link to be queried (uint)
+
+        capability: Specifies the nvmlNvLinkCapability_t to be queried
+
+    Returns:
+        cap_result: A boolean for the queried capability indicating that feature
+        is available
+
     """
     c_link = c_uint(link)
     c_cap_result = c_bool()
@@ -1857,9 +1876,21 @@ def nvmlDeviceGetNvLinkCapability(device, link, cap):
     return c_cap_result.value
 
 def nvmlDeviceGetNvLinkErrorCounter(device, link, counter):
-    """
+    """Retrieve the specified error counter value.
+
     Retrieves the specified error counter value. Please refer to
     _nvmlNvLinkErrorCounter_t for error counters that are available.
+
+    Args:
+        device: The identifier of the target device
+
+        link: Specifies the NvLink link to be queried (uint)
+
+        counter: Specifies the NvLink counter to be queried
+
+    Returns:
+        value: The specified counter value
+
     """
     c_link = c_uint(link)
     c_cap_result = c_bool()
@@ -1870,9 +1901,19 @@ def nvmlDeviceGetNvLinkErrorCounter(device, link, counter):
     return c_value.value
 
 def nvmlDeviceGetNvLinkRemotePciInfo(device, link):
-    """
+    """Retrieve the PCI information for the remote node on a NvLink link.
+
     Retrieves the PCI information for the remote node on a NvLink link. Note:
     pciSubSystemId is not filled in this function and is indeterminate.
+
+    Args:
+        device: The identifier of the target device
+
+        link: Specifies the NvLink link to be queried (uint)
+
+    Returns:
+        pci: nvmlPciInfo_t of the remote node for the specified link
+
     """
     c_link = c_uint(link)
     c_pci = c_nvmlPciInfo_t()
@@ -1882,8 +1923,19 @@ def nvmlDeviceGetNvLinkRemotePciInfo(device, link):
     return c_pci
 
 def nvmlDeviceGetNvLinkState(device, link):
-    """
+    """Retrieve the state of the device's NvLink for the link specified.
+
     Retrieves the state of the device's NvLink for the link specified.
+
+    Args:
+        device: The identifier of the target device
+
+        link: Specifies the NvLink link to be queried (uint)
+
+    Returns:
+        mode: nvmlEnableState_t where NVML_FEATURE_ENABLED indicates that the
+        link is active and NVML_FEATURE_DISABLED indicates it is inactive.
+
     """
     c_link = c_uint(link)
     c_mode = _nvmlEnableState_t()
@@ -1893,10 +1945,22 @@ def nvmlDeviceGetNvLinkState(device, link):
     return c_mode.value
 
 def nvmlDeviceGetNvLinkUtilizationControl(device, link, counter):
-    """
+    """Get NVLINK utilization counter control information
+
     Get the NVLINK utilization counter control information for the specified
     counter, 0 or 1. Please refer to nvmlNvLinkUtilizationControl_t for the
     structure definition. [Note: nvmlNvLinkUtilizationControl_t not documented]
+
+    Args:
+        device: The identifier of the target device
+
+        link: Specifies the NvLink link to be queried (uint)
+
+        counter: Specifies the counter that should be set (0 or 1)
+
+    Returns:
+        control: The nvmlNvLinkUtilizationControl_t object (an integer)
+
     """
     c_link = c_uint(link)
     c_counter = c_uint(counter)
@@ -1907,11 +1971,24 @@ def nvmlDeviceGetNvLinkUtilizationControl(device, link, counter):
     return c_control.value
 
 def nvmlDeviceGetNvLinkUtilizationCounter(device, link, counter):
-    """
+    """Retrieve an NVLINK utilization counter.
+
     Retrieve the NVLINK utilization counter based on the current control for a
     specified counter. In general it is good practice to use
     nvmlDeviceSetNvLinkUtilizationControl before reading the utilization
     counters as they have no default state.
+
+    Args:
+        device: The identifier of the target device
+
+        link: Specifies the NvLink link to be queried (uint)
+
+        counter: Specifies the counter that should be set (0 or 1)
+
+    Returns:
+        rxtx_dict: Dictionary with `rx` key (value is "receive" counter) and
+        `tx` key (value is "transmit" counter)
+
     """
     c_link = c_uint(link)
     c_counter = c_uint(counter)
@@ -1920,11 +1997,22 @@ def nvmlDeviceGetNvLinkUtilizationCounter(device, link, counter):
     fn = get_func_pointer("nvmlDeviceGetNvLinkUtilizationCounter")
     ret = fn(device, c_link, c_counter, byref(c_rx), byref(c_tx))
     check_return(ret)
-    return {'rx': c_rx.value, 'tx': c_rx.value}
+    rxtx_dict = {'rx': c_rx.value, 'tx': c_rx.value}
+    return rxtx_dict
 
 def nvmlDeviceGetNvLinkVersion(device, link):
-    """
+    """Retrieve NvLink version.
+
     Retrieves the version of the device's NvLink for the link specified.
+
+    Args:
+        device: The identifier of the target device
+
+        link: Specifies the NvLink link to be queried (uint)
+
+    Returns:
+        version: Requested NvLink version (uint)
+
     """
     c_link = c_uint(link)
     c_version = c_uint()
@@ -1934,9 +2022,16 @@ def nvmlDeviceGetNvLinkVersion(device, link):
     return c_version.value
 
 def nvmlDeviceResetNvLinkErrorCounters(device, link):
-    """
-    Resets all error counters to zero Please refer to nvmlNvLinkErrorCounter_t
+    """Reset all error counters to zero.
+
+    Resets all error counters to zero. Please refer to nvmlNvLinkErrorCounter_t
     for the list of error counters that are reset.
+
+    Args:
+        device: The identifier of the target device
+
+        link: Specifies the NvLink link to be queried (uint)
+
     """
     c_link = c_uint(link)
     fn = get_func_pointer("nvmlDeviceResetNvLinkErrorCounters")
@@ -1944,9 +2039,18 @@ def nvmlDeviceResetNvLinkErrorCounters(device, link):
     return check_return(ret)
 
 def nvmlDeviceResetNvLinkUtilizationCounter(device, link, counter):
-    """
-    Reset the NVLINK utilization counters Both the receive and transmit
+    """Reset the NVLINK utilization counters.
+
+    Reset the NVLINK utilization counters. Both the receive and transmit
     counters are operated on by this function.
+
+    Args:
+        device: The identifier of the target device
+
+        link: Specifies the NvLink link to be queried (uint)
+
+        counter: Specifies the counter that should be reset (0 or 1)
+
     """
     c_link = c_uint(link)
     c_counter = c_uint(counter)
@@ -1955,13 +2059,25 @@ def nvmlDeviceResetNvLinkUtilizationCounter(device, link, counter):
     return check_return(ret)
 
 def nvmlDeviceSetNvLinkUtilizationControl(device, link, counter, control, reset):
-    """
+    """Set the NVLINK utilization counter control.
+
     Set the NVLINK utilization counter control information for the specified
     counter, 0 or 1. Please refer to nvmlNvLinkUtilizationControl_t for the
     structure definition. Performs a reset of the counters if the reset
-    parameter is non-zero.
+    parameter is non-zero. Note: nvmlNvLinkUtilizationControl_t is an integer.
 
-    Note: nvmlNvLinkUtilizationControl_t is an integer.
+    Args:
+        device: The identifier of the target device
+
+        link: Specifies the NvLink link to be queried (uint)
+
+        counter: Specifies the counter that should be set (0 or 1)
+
+        reset: Resets the counters on set if non-zero (uint)
+
+    Returns:
+        control: The nvmlNvLinkUtilizationControl_t control setting
+
     """
     c_link = c_uint(link)
     c_counter = c_uint(counter)

--- a/pynvml/nvml.py
+++ b/pynvml/nvml.py
@@ -217,6 +217,39 @@ NVML_TOPOLOGY_HOSTBRIDGE = 30
 NVML_TOPOLOGY_CPU = 40
 NVML_TOPOLOGY_SYSTEM = 50
 
+_nvmlNvLinkCapability_t = c_uint
+NVML_NVLINK_CAP_P2P_SUPPORTED = 0
+NVML_NVLINK_CAP_SYSMEM_ACCESS = 1
+NVML_NVLINK_CAP_P2P_ATOMICS = 2
+NVML_NVLINK_CAP_SYSMEM_ATOMICS = 3
+NVML_NVLINK_CAP_SLI_BRIDGE = 4
+NVML_NVLINK_CAP_VALID = 5
+NVML_NVLINK_CAP_COUNT = 6
+
+_nvmlNvLinkErrorCounter_t = c_uint
+NVML_NVLINK_ERROR_DL_REPLAY = 0
+NVML_NVLINK_ERROR_DL_RECOVERY = 1
+NVML_NVLINK_ERROR_DL_CRC_FLIT = 2
+NVML_NVLINK_ERROR_DL_CRC_DATA = 3
+NVML_NVLINK_ERROR_COUNT = 4
+
+_nvmlNvLinkUtilizationCountPktTypes_t = c_uint
+NVML_NVLINK_COUNTER_PKTFILTER_NOP = 0x1
+NVML_NVLINK_COUNTER_PKTFILTER_READ = 0x2
+NVML_NVLINK_COUNTER_PKTFILTER_WRITE = 0x4
+NVML_NVLINK_COUNTER_PKTFILTER_RATOM = 0x8
+NVML_NVLINK_COUNTER_PKTFILTER_NRATOM = 0x10
+NVML_NVLINK_COUNTER_PKTFILTER_FLUSH = 0x20
+NVML_NVLINK_COUNTER_PKTFILTER_RESPDATA = 0x40
+NVML_NVLINK_COUNTER_PKTFILTER_RESPNODATA = 0x80
+NVML_NVLINK_COUNTER_PKTFILTER_ALL = 0xFF
+
+_nvmlNvLinkUtilizationCountUnits_t = c_uint
+NVML_NVLINK_COUNTER_UNIT_CYCLES = 0
+NVML_NVLINK_COUNTER_UNIT_PACKETS = 1
+NVML_NVLINK_COUNTER_UNIT_BYTES = 2
+NVML_NVLINK_COUNTER_UNIT_COUNT = 3
+
 # C preprocessor defined values
 nvmlFlagDefault             = 0
 nvmlFlagForce               = 1
@@ -229,7 +262,11 @@ NVML_SYSTEM_NVML_VERSION_BUFFER_SIZE         = 80
 NVML_DEVICE_NAME_BUFFER_SIZE                 = 64
 NVML_DEVICE_SERIAL_BUFFER_SIZE               = 30
 NVML_DEVICE_VBIOS_VERSION_BUFFER_SIZE        = 32
-NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE           = 16
+NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE           = 32
+NVML_DEVICE_PCI_BUS_ID_BUFFER_V2_SIZE        = 16
+
+# NvLink
+NVML_NVLINK_MAX_LINKS = 6
 
 NVML_VALUE_NOT_AVAILABLE_ulonglong = c_ulonglong(-1)
 NVML_VALUE_NOT_AVAILABLE_uint = c_uint(-1)
@@ -577,6 +614,8 @@ class c_nvmlViolationTime_t(PrintableStructure):
         ('violationTime', c_ulonglong),
     ]
 
+
+
 ## Event structures
 class struct_c_nvmlEventSet_t(Structure):
     pass # opaque handle
@@ -631,6 +670,17 @@ class c_nvmlAccountingStats_t(PrintableStructure):
         ('startTime', c_ulonglong),
         ('isRunning', c_uint),
         ('reserved', c_uint * 5)
+    ]
+
+class c_nvmlPciInfo_t(PrintableStructure):
+    _fields_ = [
+        ('bus', c_uint),
+        ('busId', c_char),
+        ('busIdLegacy', c_char),
+        ('device', c_uint),
+        ('domain', c_uint),
+        ('pciDeviceId', c_uint),
+        ('pciSubSystemId', c_uint)
     ]
 
 ## ========================================================================== ##
@@ -1766,3 +1816,91 @@ def nvmlDeviceGetTopologyCommonAncestor(device1, device2):
     ret = fn(device1, device2, byref(c_level))
     check_return(ret)
     return c_level.value
+
+def nvmlDeviceFreezeNvLinkUtilizationCounter(device, link, counter, freeze):
+    """
+    Freeze the NVLINK utilization counters. Both the receive and transmit
+    counters are operated on by this function.
+    """
+    c_link = c_uint(link)
+    c_counter = c_uint(counter)
+    fn = get_func_pointer("nvmlDeviceFreezeNvLinkUtilizationCounter")
+    ret = fn(device, c_link, c_counter, _nvmlEnableState_t(freeze))
+    return check_return(ret)
+
+def nvmlDeviceGetNvLinkCapability(device, link, cap):
+    """
+    Retrieves the requested capability from the device's NvLink for the link
+    specified. Please refer to the nvmlNvLinkCapability_t structure for the
+    specific caps that can be queried. The return value should be treated as a
+    boolean.
+    """
+    c_link = c_uint(link)
+    c_cap_result = c_bool()
+    fn = get_func_pointer("nvmlDeviceGetNvLinkCapability")
+    ret = fn(device, c_link, _nvmlNvLinkCapability_t(cap), byref(c_cap_result))
+    check_return(ret)
+    return c_cap_result.value
+
+def nvmlDeviceGetNvLinkErrorCounter(device, link, counter):
+    """
+    Retrieves the specified error counter value. Please refer to
+    _nvmlNvLinkErrorCounter_t for error counters that are available.
+    """
+    c_link = c_uint(link)
+    c_cap_result = c_bool()
+    c_value = c_ulonglong()
+    fn = get_func_pointer("nvmlDeviceGetNvLinkErrorCounter")
+    ret = fn(device, c_link, _nvmlNvLinkErrorCounter_t(counter), byref(c_value))
+    check_return(ret)
+    return c_value.value
+
+def nvmlDeviceGetNvLinkRemotePciInfo(device, link):
+    """
+    Retrieves the PCI information for the remote node on a NvLink link. Note:
+    pciSubSystemId is not filled in this function and is indeterminate.
+    """
+    c_link = c_uint(link)
+    c_pci = c_nvmlPciInfo_t()
+    fn = get_func_pointer("nvmlDeviceGetNvLinkRemotePciInfo")
+    ret = fn(device, c_link, byref(c_pci))
+    check_return(ret)
+    return c_pci
+
+def nvmlDeviceGetNvLinkState(device, link):
+    """
+    Retrieves the state of the device's NvLink for the link specified.
+    """
+    c_link = c_uint(link)
+    c_mode = _nvmlEnableState_t()
+    fn = get_func_pointer("nvmlDeviceGetNvLinkState")
+    ret = fn(device, c_link, byref(c_mode))
+    check_return(ret)
+    return c_mode.value
+
+
+
+def nvmlDeviceGetNvLinkVersion(device, link):
+    c_link = c_uint(link)
+    c_version = c_uint()
+    fn = get_func_pointer("nvmlDeviceGetNvLinkVersion")
+    ret = fn(device, c_link, byref(c_version))
+    check_return(ret)
+    return c_version.value
+
+def nvmlDeviceGetNvLinkUtilizationCounter(device, link, counter):
+    c_link = c_uint(link)
+    c_counter = c_uint(counter)
+    c_rx = c_ulonglong()
+    c_tx = c_ulonglong()
+    fn = get_func_pointer("nvmlDeviceGetNvLinkUtilizationCounter")
+    ret = fn(device, c_link, c_counter, byref(c_rx), byref(c_tx))
+    check_return(ret)
+    return {'rx': c_rx.value, 'tx': c_rx.value}
+
+def nvmlDeviceResetNvLinkUtilizationCounter(device, link, counter):
+    c_link = c_uint(link)
+    c_counter = c_uint(counter)
+    fn = get_func_pointer("nvmlDeviceResetNvLinkUtilizationCounter")
+    ret = fn(device, c_link, c_counter)
+    return check_return(ret)

--- a/pynvml/nvml.py
+++ b/pynvml/nvml.py
@@ -2075,8 +2075,8 @@ def nvmlDeviceSetNvLinkUtilizationControl(device, link, counter, control, reset)
 
         reset: Resets the counters on set if non-zero (uint)
 
-    Returns:
         control: The nvmlNvLinkUtilizationControl_t control setting
+                 Note: 0 == cycles, 1 == packets, 2 == bytes
 
     """
     c_link = c_uint(link)

--- a/pynvml/tests/test_nvml.py
+++ b/pynvml/tests/test_nvml.py
@@ -262,8 +262,8 @@ def test_nvml_nvlink_capability(ngpus, handles, cap_type):
 # Test pynvml.nvmlDeviceGetNvLinkUtilizationControl
 # Test pynvml.nvmlDeviceFreezeNvLinkUtilizationCounter
 @pytest.mark.parametrize('counter', [0, 1])
-def test_nvml_nvlink_counters(ngpus, handles, counter):
-    control = 1
+@pytest.mark.parametrize('control', [0, 1, 2])
+def test_nvml_nvlink_counters(ngpus, handles, counter, control):
     reset = 0
     for i in range(ngpus):
         for j in range(pynvml.NVML_NVLINK_MAX_LINKS):
@@ -279,7 +279,6 @@ def test_nvml_nvlink_counters(ngpus, handles, counter):
             ctl = pynvml.nvmlDeviceGetNvLinkUtilizationControl(
                 handles[i], j, counter
             )
-            #print((i,j,countdict['rx'],countdict['tx'], ctl))
             assert countdict['rx'] >= 0
             assert countdict['tx'] >= 0
             assert ctl == control

--- a/pynvml/tests/test_nvml.py
+++ b/pynvml/tests/test_nvml.py
@@ -78,17 +78,20 @@ def test_nvmlSystemGetDriverVersion(nvml):
 
 # Test pynvml.nvmlDeviceGetHandleBySerial
 def test_nvmlDeviceGetHandleBySerial(ngpus, serials):
-    handles = [ pynvml.nvmlDeviceGetHandleBySerial(serials[i]) for i in range(ngpus) ]
+    handles = [ pynvml.nvmlDeviceGetHandleBySerial(serials[i])
+                for i in range(ngpus) ]
     assert len(handles) == ngpus
 
 # Test pynvml.nvmlDeviceGetHandleByUUID
 def test_nvmlDeviceGetHandleByUUID(ngpus, uuids):
-    handles = [ pynvml.nvmlDeviceGetHandleByUUID(uuids[i]) for i in range(ngpus) ]
+    handles = [ pynvml.nvmlDeviceGetHandleByUUID(uuids[i])
+                for i in range(ngpus) ]
     assert len(handles) == ngpus
 
 # Test pynvml.nvmlDeviceGetHandleByPciBusId
 def test_nvmlDeviceGetHandleByPciBusId(ngpus, pci_info):
-    handles = [ pynvml.nvmlDeviceGetHandleByPciBusId(pci_info[i].busId) for i in range(ngpus) ]
+    handles = [ pynvml.nvmlDeviceGetHandleByPciBusId(pci_info[i].busId)
+                for i in range(ngpus) ]
     assert len(handles) == ngpus
 
 # [Skipping] pynvml.nvmlDeviceGetName
@@ -137,7 +140,8 @@ def test_nvmlDeviceGetPowerUsage(ngpus, handles):
 def test_nvmlDeviceGetMemoryInfo(ngpus, handles):
     for i in range(ngpus):
         meminfo = pynvml.nvmlDeviceGetMemoryInfo( handles[i] )
-        assert (meminfo.used <= meminfo.total) and (meminfo.free <= meminfo.total)
+        assert ((meminfo.used <= meminfo.total)
+                and (meminfo.free <= meminfo.total))
 
 # [Skipping] pynvml.nvmlDeviceGetBAR1MemoryInfo
 # [Skipping] pynvml.nvmlDeviceGetComputeMode
@@ -207,11 +211,18 @@ def test_nvmlDeviceGetUtilizationRates(ngpus, handles):
 # Test pynvml.nvmlDeviceGetPcieThroughput
 def test_nvmlDeviceGetPcieThroughput(ngpus, handles):
     for i in range(ngpus):
-        tx_bytes_tp = pynvml.nvmlDeviceGetPcieThroughput(handles[i], NVML_PCIE_UTIL_TX_BYTES)
+        tx_bytes_tp = pynvml.nvmlDeviceGetPcieThroughput(
+            handles[i],
+            NVML_PCIE_UTIL_TX_BYTES
+        )
         assert tx_bytes_tp >= 0
-        rx_bytes_tp = pynvml.nvmlDeviceGetPcieThroughput(handles[i], NVML_PCIE_UTIL_RX_BYTES)
+        rx_bytes_tp = pynvml.nvmlDeviceGetPcieThroughput(
+            handles[i], NVML_PCIE_UTIL_RX_BYTES
+        )
         assert rx_bytes_tp >= 0
-        count_tp = pynvml.nvmlDeviceGetPcieThroughput(handles[i], NVML_PCIE_UTIL_COUNT)
+        count_tp = pynvml.nvmlDeviceGetPcieThroughput(
+            handles[i], NVML_PCIE_UTIL_COUNT
+        )
         assert count_tp >= 0
 
 # [Skipping] pynvml.nvmlSystemGetTopologyGpuSet
@@ -219,11 +230,17 @@ def test_nvmlDeviceGetPcieThroughput(ngpus, handles):
 # [Skipping] pynvml.nvmlDeviceGetTopologyCommonAncestor
 
 # Test pynvml.nvmlDeviceGetNvLinkVersion
-def test_nvmlDeviceGetNvLinkVersion(ngpus, handles):
+# Test pynvml.nvmlDeviceGetNvLinkState
+# Test pynvml.nvmlDeviceGetNvLinkRemotePciInfo
+def test_nvml_nvlink_properties(ngpus, handles):
     for i in range(ngpus):
         for j in range(pynvml.NVML_NVLINK_MAX_LINKS):
-            version = pynvml.nvmlDeviceGetNvLinkVersion( handles[i], j )
+            version = pynvml.nvmlDeviceGetNvLinkVersion(handles[i], j)
             assert version >= 1
+            state = pynvml.nvmlDeviceGetNvLinkState(handles[i], j)
+            assert state >= 0
+            pci_info = pynvml.nvmlDeviceGetNvLinkRemotePciInfo(handles[i], j)
+            assert isinstance(pci_info, pynvml.c_nvmlPciInfo_t)
 
 # Test pynvml.nvmlDeviceGetNvLinkCapability
 @pytest.mark.parametrize('cap_type', [
@@ -233,22 +250,60 @@ def test_nvmlDeviceGetNvLinkVersion(ngpus, handles):
     pynvml.NVML_NVLINK_CAP_SYSMEM_ATOMICS, # System memory atomics are supported
     pynvml.NVML_NVLINK_CAP_SLI_BRIDGE,     # SLI is supported over this link
     pynvml.NVML_NVLINK_CAP_VALID])         # Link is supported on this device
-def test_nvmlDeviceGetNvLinkCapability(ngpus, handles):
+def test_nvml_nvlink_capability(ngpus, handles, cap_type):
     for i in range(ngpus):
         for j in range(pynvml.NVML_NVLINK_MAX_LINKS):
             cap = pynvml.nvmlDeviceGetNvLinkCapability(handles[i], j, cap_type)
-            #print((i,j,cap))
             assert cap >= 0
 
+# Test pynvml.nvmlDeviceResetNvLinkUtilizationCounter
+# Test pynvml.nvmlDeviceSetNvLinkUtilizationControl
 # Test pynvml.nvmlDeviceGetNvLinkUtilizationCounter
+# Test pynvml.nvmlDeviceGetNvLinkUtilizationControl
+# Test pynvml.nvmlDeviceFreezeNvLinkUtilizationCounter
 @pytest.mark.parametrize('counter', [0, 1])
-def test_nvmlDeviceGetNvLinkUtilizationCounter(ngpus, handles, counter):
+def test_nvml_nvlink_counters(ngpus, handles, counter):
+    control = 1
+    reset = 0
     for i in range(ngpus):
         for j in range(pynvml.NVML_NVLINK_MAX_LINKS):
-            pynvml.nvmlDeviceResetNvLinkUtilizationCounter(device, link, counter)
+            assert pynvml.nvmlDeviceResetNvLinkUtilizationCounter(
+                handles[i], j, counter
+            ) == pynvml.NVML_SUCCESS
+            pynvml.nvmlDeviceSetNvLinkUtilizationControl(
+                handles[i], j, counter, control, reset
+            )
             countdict = pynvml.nvmlDeviceGetNvLinkUtilizationCounter(
                 handles[i], j, counter
             )
-            #print((i,j,countdict['rx'],countdict['tx']))
+            ctl = pynvml.nvmlDeviceGetNvLinkUtilizationControl(
+                handles[i], j, counter
+            )
+            #print((i,j,countdict['rx'],countdict['tx'], ctl))
             assert countdict['rx'] >= 0
             assert countdict['tx'] >= 0
+            assert ctl == control
+            assert pynvml.nvmlDeviceFreezeNvLinkUtilizationCounter(
+                handles[i], j, counter, 1
+            ) == pynvml.NVML_SUCCESS
+            assert pynvml.nvmlDeviceFreezeNvLinkUtilizationCounter(
+                handles[i], j, counter, 0
+            ) == pynvml.NVML_SUCCESS
+
+# Test pynvml.nvmlDeviceResetNvLinkErrorCounters
+# Test pynvml.nvmlDeviceGetNvLinkErrorCounter
+@pytest.mark.parametrize('error_type', [
+    pynvml.NVML_NVLINK_ERROR_DL_REPLAY,
+    pynvml.NVML_NVLINK_ERROR_DL_RECOVERY,
+    pynvml.NVML_NVLINK_ERROR_DL_CRC_FLIT,
+    pynvml.NVML_NVLINK_ERROR_DL_CRC_DATA])
+def test_nvml_nvlink_error_counters(ngpus, handles, error_type):
+    for i in range(ngpus):
+        for j in range(pynvml.NVML_NVLINK_MAX_LINKS):
+            assert pynvml.nvmlDeviceResetNvLinkErrorCounters(
+                handles[i], j
+            ) == pynvml.NVML_SUCCESS
+            error_count = pynvml.nvmlDeviceGetNvLinkErrorCounter(
+                handles[i], j, error_type
+            )
+            assert error_count >= 0


### PR DESCRIPTION
This PR addresses [issue#8](https://github.com/gpuopenanalytics/pynvml/issues/8).  Adding wrappers (and corresponding tests) for the [11 NvLink methods](https://docs.nvidia.com/deploy/nvml-api/group__NvLink.html#group__NvLink) available in NVML.