### PR TITLE
Add nvmlDeviceGetTotalEnergyConsumption

### DIFF
--- a/pynvml/nvml.py
+++ b/pynvml/nvml.py
@@ -1239,11 +1239,11 @@ def nvmlDeviceGetEnforcedPowerLimit(handle):
     return c_limit.value
 
 def nvmlDeviceGetPowerUsage(handle):
-    c_watts = c_uint()
+    c_mWatts = c_uint()
     fn = get_func_pointer("nvmlDeviceGetPowerUsage")
-    ret = fn(handle, byref(c_watts))
+    ret = fn(handle, byref(c_mWatts))
     check_return(ret)
-    return c_watts.value
+    return c_mWatts.value
 
 def nvmlDeviceGetTotalEnergyConsumption(handle):
     c_mJoules = c_uint()

--- a/pynvml/nvml.py
+++ b/pynvml/nvml.py
@@ -1245,6 +1245,13 @@ def nvmlDeviceGetPowerUsage(handle):
     check_return(ret)
     return c_watts.value
 
+def nvmlDeviceGetTotalEnergyConsumption(handle):
+    c_mJoules = c_uint()
+    fn = get_func_pointer("nvmlDeviceGetTotalEnergyConsumption")
+    ret = fn(handle, byref(c_mJoules))
+    check_return(ret)
+    return c_mJoules.value
+
 # Added in 4.304
 def nvmlDeviceGetGpuOperationMode(handle):
     c_currState = _nvmlGpuOperationMode_t()

--- a/pynvml/tests/test_nvml.py
+++ b/pynvml/tests/test_nvml.py
@@ -1,5 +1,6 @@
 import pynvml
 import pytest
+import time
 import os
 
 NVML_PCIE_UTIL_TX_BYTES = pynvml.NVML_PCIE_UTIL_TX_BYTES
@@ -131,6 +132,21 @@ def test_nvmlDeviceGetPowerUsage(ngpus, handles):
     for i in range(ngpus):
         power_watts = pynvml.nvmlDeviceGetPowerUsage( handles[i] )
         assert power_watts >= 0.0
+
+# Test pynvml.nvmlDeviceGetTotalEnergyConsumption
+def test_nvmlDeviceGetTotalEnergyConsumption(ngpus, handles):
+    for i in range(ngpus):
+        energy_mJoules1 = pynvml.nvmlDeviceGetTotalEnergyConsumption(
+            handles[i])
+        for j in range(10):  # idle for 150 ms
+            time.sleep(0.015)  # and check for increase every 15 ms
+            energy_mJoules2 = pynvml.nvmlDeviceGetTotalEnergyConsumption(
+                handles[i])
+            assert energy_mJoules2 >= energy_mJoules1
+            if energy_mJoules2 > energy_mJoules1:
+                break
+        else:
+            assert False, "energy did not increase across 150 ms interval"
 
 # [Skipping] pynvml.nvmlDeviceGetGpuOperationMode
 # [Skipping] pynvml.nvmlDeviceGetCurrentGpuOperationMode

--- a/pynvml/tests/test_nvml.py
+++ b/pynvml/tests/test_nvml.py
@@ -130,8 +130,8 @@ def test_nvmlDeviceGetHandleByPciBusId(ngpus, pci_info):
 # Test pynvml.nvmlDeviceGetPowerUsage
 def test_nvmlDeviceGetPowerUsage(ngpus, handles):
     for i in range(ngpus):
-        power_watts = pynvml.nvmlDeviceGetPowerUsage( handles[i] )
-        assert power_watts >= 0.0
+        power_mWatts = pynvml.nvmlDeviceGetPowerUsage(handles[i])
+        assert power_mWatts >= 0.0
 
 # Test pynvml.nvmlDeviceGetTotalEnergyConsumption
 def test_nvmlDeviceGetTotalEnergyConsumption(ngpus, handles):


### PR DESCRIPTION
Retrieves total energy consumption for this GPU in millijoules (mJ) since the driver was last reloaded. Requires Volta or newer.

**NVML Documentation**: [`nvmlReturn_t nvmlDeviceGetTotalEnergyConsumption ( nvmlDevice_t device, unsigned long long* energy )
`](https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g732ab899b5bd18ac4bfb93c02de4900a)

Note: I could not find where this function had been added in the [NVML Change Log](https://docs.nvidia.com/deploy/nvml-api/change-log.html#change-log) or in the [API Reference Manual](https://developer.nvidia.com/nvidia-management-library-nvml) -- unsure if there was some underlying reason this had been omitted from the Python bindings.

Tested by running the following code on my notebook (GeForce GTX 1650 with Max-Q, driver version 430.09):

```python
import pynvml as N

N.nvmlInit()

handles = []
for index in range(N.nvmlDeviceGetCount()):
    handles.append(N.nvmlDeviceGetHandleByIndex(index))

for handle in handles:
    energy = N.nvmlDeviceGetTotalEnergyConsumption(handle)
    print(energy)
```

I've also verified that this returns a `NOT_SUPPORTED` error if running on a GPU/driver that does not support energy readings (even if it does support power readings).