### PR TITLE
Fix version check test

### DIFF
--- a/pynvml/tests/test_nvml.py
+++ b/pynvml/tests/test_nvml.py
@@ -2,6 +2,7 @@ import pynvml
 import pytest
 import time
 import os
+from distutils.version import LooseVersion
 
 NVML_PCIE_UTIL_TX_BYTES = pynvml.NVML_PCIE_UTIL_TX_BYTES
 NVML_PCIE_UTIL_RX_BYTES = pynvml.NVML_PCIE_UTIL_RX_BYTES
@@ -57,8 +58,7 @@ def test_nvmlSystemGetNVMLVersion(nvml):
     vsn = 0.0
     vsn = pynvml.nvmlSystemGetNVMLVersion().decode()
     print('[NVML Version: '+vsn+']', end =' ')
-    #Check if the major version number is greater than 0
-    assert int(vsn.split('.')[0]) > 0.0
+    assert vsn > LooseVersion("0.0")
 
 # Test pynvml.nvmlSystemGetProcessName
 def test_nvmlSystemGetProcessName(nvml):
@@ -72,8 +72,7 @@ def test_nvmlSystemGetDriverVersion(nvml):
     vsn = 0.0
     vsn = pynvml.nvmlSystemGetDriverVersion().decode()
     print('[Driver Version: '+vsn+']', end =' ')
-    #Check if the major version number is greater than 0
-    assert int(vsn.split('.')[0]) > 0.0 # Developing with 396.44
+    assert vsn > LooseVersion("0.0") # Developing with 396.44
 
 ## Unit "Get" Functions (Skipping for now) ##
 

--- a/pynvml/tests/test_nvml.py
+++ b/pynvml/tests/test_nvml.py
@@ -55,9 +55,10 @@ def pci_info(ngpus, handles):
 # Test pynvml.nvmlSystemGetNVMLVersion
 def test_nvmlSystemGetNVMLVersion(nvml):
     vsn = 0.0
-    vsn = float(pynvml.nvmlSystemGetDriverVersion().decode())
-    print('[NVML Version: '+str(vsn)+']', end =' ')
-    assert vsn > 0.0
+    vsn = pynvml.nvmlSystemGetNVMLVersion().decode()
+    print('[NVML Version: '+vsn+']', end =' ')
+    #Check if the major version number is greater than 0
+    assert int(vsn.split('.')[0]) > 0.0
 
 # Test pynvml.nvmlSystemGetProcessName
 def test_nvmlSystemGetProcessName(nvml):
@@ -69,9 +70,10 @@ def test_nvmlSystemGetProcessName(nvml):
 # Test pynvml.nvmlSystemGetDriverVersion
 def test_nvmlSystemGetDriverVersion(nvml):
     vsn = 0.0
-    vsn = float(pynvml.nvmlSystemGetDriverVersion().decode())
-    print('[Driver Version: '+str(vsn)+']', end =' ')
-    assert vsn > 0.0 # Developing with 396.44
+    vsn = pynvml.nvmlSystemGetDriverVersion().decode()
+    print('[Driver Version: '+vsn+']', end =' ')
+    #Check if the major version number is greater than 0
+    assert int(vsn.split('.')[0]) > 0.0 # Developing with 396.44
 
 ## Unit "Get" Functions (Skipping for now) ##
 


### PR DESCRIPTION
1. Proposed fix for https://github.com/gpuopenanalytics/pynvml/issues/22 where I have removed the typecast of the version to `float`, as that does not work with driver versions like `440.33.01` or `418.87.00`. I have modified the version check test case to check if the major version number is greater than 0. Please let me know if there are suggestions to improve the test. 
2. I have also modified the `test_nvmlSystemGetNVMLVersion` to test the API `nvmlSystemGetNVMLVersion()` instead of `nvmlSystemGetDriverVersion()`, which I think it was intended to. Else `test_nvmlSystemGetNVMLVersion()` and `test_nvmlSystemGetDriverVersion()` were testing the same API.