### PR TITLE
Support python2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 *.py[cod]
 *$py.class
+dist/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+Fork notes
+==========
+
+Changes from upstream:
+----------------------
+- support for python 2
+- additional tests
+- xfail tests on unsupported hardware or driver versions
+- build and test automation using Docker
+
+Build, test, export wheel:
+--------------------------
+Run `./ci/build` from repository root. If successful, wheel will be placed in `dist` directory.
+
+
+(upstream readme below)
+
+----
+
 Python bindings to the NVIDIA Management Library
 ================================================
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1.2
+# pynvml as distributed on pypi requires python 3.6+
+# This Dockerfile builds and tests for python 2.7
+#
+# Supports Ubuntu 16.04 and 20.04
+
+#### Build Stage
+################################################################################
+ARG UBUNTU_BASE_TAG=16.04
+FROM ubuntu:${UBUNTU_BASE_TAG} as pynvml-build
+LABEL description="Build image for pynvml"
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update \
+    && apt-get install -y \
+        curl \
+        git \
+        python \
+    && apt-get clean
+
+# pip and virtualenv (available as package on 16.04 but not 20.04)
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2 \
+     && python2 -m pip --no-cache-dir install virtualenv
+
+ADD . /sandbox
+WORKDIR /sandbox
+
+RUN virtualenv env \
+    && source env/bin/activate \
+    && pip install --no-cache-dir . \
+    && pip install --upgrade --no-cache-dir pytest future wheel setuptools
+
+CMD nvidia-smi && source env/bin/activate \
+    && pytest -rxXspF pynvml/tests \
+    && python setup.py bdist_wheel --dist-dir /sandbox/dist

--- a/ci/build
+++ b/ci/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+# run this file from the repository root
+set -ex
+
+export DOCKER_BUILDKIT=1
+mkdir -p dist
+
+# Build
+docker build \
+    --progress=plain \
+    --target pynvml-build \
+    --tag pynvml-build \
+    --file ci/Dockerfile \
+    .
+
+# Test and export wheel
+docker run \
+    --rm \
+    --gpus all \
+    --mount type=bind,source="$(pwd)"/dist,target=/sandbox/dist \
+    pynvml-build

--- a/pynvml/tests/conftest.py
+++ b/pynvml/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+import pynvml
+
+
+XFAIL_UNSUPPORTED_HW = "Not supported on this hardware."
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_pyfunc_call(pyfuncitem):
+    try:
+        outcome = yield
+        outcome.get_result()
+    except pynvml.NVMLError_NotSupported:
+        pytest.xfail(XFAIL_UNSUPPORTED_HW)

--- a/pynvml/tests/test_nvml.py
+++ b/pynvml/tests/test_nvml.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import pynvml
 import pytest
 import time
@@ -9,6 +11,8 @@ NVML_PCIE_UTIL_RX_BYTES = pynvml.NVML_PCIE_UTIL_RX_BYTES
 NVML_PCIE_UTIL_COUNT = pynvml.NVML_PCIE_UTIL_COUNT
 
 XFAIL_LEGACY_NVLINK_MSG = "Legacy NVLink test expected to fail."
+XFAIL_SINGLE_GPU = "Cannot run test on single GPU"
+XFAIL_VPGU = "Not available on vGPU"
 
 # Fixture to initialize and finalize nvml
 @pytest.fixture(scope="module")
@@ -39,6 +43,15 @@ def ngpus(nvml):
     print("[" + str(result) + " GPUs]", end=" ")
     return result
 
+# check if vGPU
+# vGPUs do not support all features
+# see https://docs.nvidia.com/grid/14.0/pdf/grid-management-sdk-user-guide.pdf
+@pytest.fixture
+def is_vgpu(handles):
+    for handle in handles:
+        if pynvml.nvmlDeviceGetVirtualizationMode(handle) == pynvml.NVML_GPU_VIRTUALIZATION_MODE_VGPU:
+            return True
+    return False 
 
 # Get handles using pynvml.nvmlDeviceGetHandleByIndex
 @pytest.fixture
@@ -65,7 +78,9 @@ def mig_handles(nmigs):
 
 
 @pytest.fixture
-def serials(ngpus, handles):
+def serials(ngpus, handles, is_vgpu):
+    if is_vgpu:
+        pytest.xfail(XFAIL_VPGU)
     serials = [pynvml.nvmlDeviceGetSerial(handles[i]) for i in range(ngpus)]
     assert len(serials) == ngpus
     return serials
@@ -73,6 +88,8 @@ def serials(ngpus, handles):
 
 @pytest.fixture
 def uuids(ngpus, handles):
+    if is_vgpu:
+        pytest.xfail(XFAIL_VPGU)
     uuids = [pynvml.nvmlDeviceGetUUID(handles[i]) for i in range(ngpus)]
     assert len(uuids) == ngpus
     return uuids
@@ -94,7 +111,7 @@ def test_nvmlSystemGetNVMLVersion(nvml):
     vsn = 0.0
     vsn = pynvml.nvmlSystemGetNVMLVersion().decode()
     print("[NVML Version: " + vsn + "]", end=" ")
-    assert vsn > LooseVersion("0.0")
+    assert str(vsn) > LooseVersion("0.0")
 
 
 def test_nvmlSystemGetCudaDriverVersion(nvml):
@@ -116,7 +133,7 @@ def test_nvmlSystemGetDriverVersion(nvml):
     vsn = 0.0
     vsn = pynvml.nvmlSystemGetDriverVersion().decode()
     print("[Driver Version: " + vsn + "]", end=" ")
-    assert vsn > LooseVersion("0.0")  # Developing with 396.44
+    assert str(vsn) > LooseVersion("0.0")  # Developing with 396.44
 
 
 ## Unit "Get" Functions (Skipping for now) ##
@@ -231,14 +248,18 @@ def test_nvmlDeviceGetP2PStatus(handles, index):
 # [Skipping] pynvml.nvmlDeviceGetEnforcedPowerLimit
 
 # Test pynvml.nvmlDeviceGetPowerUsage
-def test_nvmlDeviceGetPowerUsage(ngpus, handles):
+def test_nvmlDeviceGetPowerUsage(ngpus, handles, is_vgpu):
+    if is_vgpu:
+        pytest.xfail(XFAIL_VPGU)
     for i in range(ngpus):
         power_mWatts = pynvml.nvmlDeviceGetPowerUsage(handles[i])
         assert power_mWatts >= 0.0
 
 
 # Test pynvml.nvmlDeviceGetTotalEnergyConsumption
-def test_nvmlDeviceGetTotalEnergyConsumption(ngpus, handles):
+def test_nvmlDeviceGetTotalEnergyConsumption(ngpus, handles, is_vgpu):
+    if is_vgpu:
+        pytest.xfail(XFAIL_VPGU)
     for i in range(ngpus):
         energy_mJoules1 = pynvml.nvmlDeviceGetTotalEnergyConsumption(handles[i])
         for j in range(10):  # idle for 150 ms
@@ -329,7 +350,11 @@ def test_nvmlDeviceGetUtilizationRates(ngpus, handles):
 # [Skipping] pynvml.nvmlDeviceGetViolationStatus
 
 # Test pynvml.nvmlDeviceGetPcieThroughput
-def test_nvmlDeviceGetPcieThroughput(ngpus, handles):
+def test_nvmlDeviceGetPcieThroughput(ngpus, handles, is_vgpu):
+    if is_vgpu:
+        pytest.xfail(XFAIL_VPGU)
+    if ngpus == 1:
+        pytest.xfail(XFAIL_SINGLE_GPU)
     for i in range(ngpus):
         tx_bytes_tp = pynvml.nvmlDeviceGetPcieThroughput(
             handles[i], NVML_PCIE_UTIL_TX_BYTES
@@ -378,6 +403,8 @@ def test_nvml_nvlink_properties(ngpus, handles, driver):
     ],
 )  # Link is supported on this device
 def test_nvml_nvlink_capability(ngpus, handles, cap_type):
+    if ngpus == 1:
+        pytest.xfail(XFAIL_SINGLE_GPU)
     for i in range(ngpus):
         for j in range(pynvml.NVML_NVLINK_MAX_LINKS):
             cap = pynvml.nvmlDeviceGetNvLinkCapability(handles[i], j, cap_type)

--- a/pynvml/tests/test_nvml.py
+++ b/pynvml/tests/test_nvml.py
@@ -248,8 +248,22 @@ def test_nvmlDeviceGetP2PStatus(handles, index):
 # [Skipping] pynvml.nvmlDeviceGetDefaultApplicationsClock
 # [Skipping] pynvml.nvmlDeviceGetSupportedMemoryClocks
 # [Skipping] pynvml.nvmlDeviceGetSupportedGraphicsClocks
-# [Skipping] pynvml.nvmlDeviceGetFanSpeed
-# [Skipping] pynvml.nvmlDeviceGetTemperature
+
+# Test pynvml.nvmlDeviceGetFanSpeed
+def test_nvmlDeviceGetFanSpeed(ngpus, handles):
+    for i in range(ngpus):
+        speed = pynvml.nvmlDeviceGetFanSpeed(handles[i])
+        assert speed >= 0
+
+
+# Test pynvml.nvmlDeviceGetTemperature
+def test_nvmlDeviceGetTemperature(ngpus, handles):
+    for i in range(ngpus):
+        temp = pynvml.nvmlDeviceGetTemperature(handles[i], pynvml.NVML_TEMPERATURE_GPU)
+        # Should not be freezing. Is that reasonable?
+        assert temp > 0
+
+
 # [Skipping] pynvml.nvmlDeviceGetTemperatureThreshold
 # [Skipping] pynvml.nvmlDeviceGetPowerState
 # [Skipping] pynvml.nvmlDeviceGetPerformanceState

--- a/pynvml/tests/test_smi.py
+++ b/pynvml/tests/test_smi.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from pynvml.smi import nvidia_smi
 import pytest
 import os
@@ -57,4 +59,4 @@ def test_temperature(ngpus, smi):
         max_temp = smi.DeviceQuery("temperature.gpu")["gpu"][i]["temperature"][
             "gpu_temp_max_threshold"
         ]
-        assert (temp > 0) and (temp < max_temp)
+        assert temp == 'N/A' or ((temp > 0) and (temp < max_temp))

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 setup(name='pynvml',
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),
-      python_requires='>=3.6',
+      python_requires='>=2.7',
       description='Python Bindings for the NVIDIA Management Library',
       long_description=long_description,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
# Support python 2

## What Did I Do?

Updated to run under python 2.7

Other improvements:
- xfail tests when running on unsupported hardware or drivers
- added temp and fan speed tests
- added build and test Docker automation

## Why Did I Do This?

The library needs to be used in a python 2.7 project.