### PR TITLE
Add deprecation warnings on import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 
 import pathlib
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import pathlib
+
+from setuptools import setup
+from setuptools.command.build_py import build_py
+from setuptools.command.editable_wheel import editable_wheel, _TopLevelFinder
+
+REDIRECTOR_PTH = "_pynvml_redirector.pth"
+REDIRECTOR_PY = "_pynvml_redirector.py"
+SITE_PACKAGES = pathlib.Path("site-packages")
+
+
+# Adapted from https://stackoverflow.com/a/71137790
+class build_py_with_redirector(build_py):  # noqa: N801
+    """Include the redirector files in the generated wheel."""
+
+    def copy_redirector_file(self, source, destination="."):
+        destination = pathlib.Path(self.build_lib) / destination
+        self.copy_file(str(source), str(destination), preserve_mode=0)
+
+    def run(self):
+        super().run()
+        self.copy_redirector_file(SITE_PACKAGES / REDIRECTOR_PTH)
+        self.copy_redirector_file(SITE_PACKAGES / REDIRECTOR_PY)
+
+    def get_source_files(self):
+        src = super().get_source_files()
+        src.extend(
+            [
+                str(SITE_PACKAGES / REDIRECTOR_PTH),
+                str(SITE_PACKAGES / REDIRECTOR_PY),
+            ]
+        )
+        return src
+
+    def get_output_mapping(self):
+        mapping = super().get_output_mapping()
+        build_lib = pathlib.Path(self.build_lib)
+        mapping[str(build_lib / REDIRECTOR_PTH)] = REDIRECTOR_PTH
+        mapping[str(build_lib / REDIRECTOR_PY)] = REDIRECTOR_PY
+        return mapping
+
+
+class TopLevelFinderWithRedirector(_TopLevelFinder):
+    """Include the redirector files in the editable wheel."""
+
+    def get_implementation(self):
+        for item in super().get_implementation():
+            yield item
+
+        with open(SITE_PACKAGES / REDIRECTOR_PTH) as f:
+            yield (REDIRECTOR_PTH, f.read())
+
+        with open(SITE_PACKAGES / REDIRECTOR_PY) as f:
+            yield (REDIRECTOR_PY, f.read())
+
+
+class editable_wheel_with_redirector(editable_wheel):
+    def _select_strategy(self, name, tag, build_lib):
+        # The default mode is "lenient" - others are "strict" and "compat".
+        # "compat" is deprecated. "strict" creates a tree of links to files in
+        # the repo. It could be implemented, but we only handle the default
+        # case for now.
+        if self.mode is not None and self.mode != "lenient":
+            raise RuntimeError(
+                "Only lenient mode is supported for editable "
+                f"install. Current mode is {self.mode}"
+            )
+
+        return TopLevelFinderWithRedirector(self.distribution, name)
+
+
+setup(
+    cmdclass={
+        "build_py": build_py_with_redirector,
+        "editable_wheel": editable_wheel_with_redirector,
+    }
+)

--- a/site-packages/_pynvml_redirector.pth
+++ b/site-packages/_pynvml_redirector.pth
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import _pynvml_redirector

--- a/site-packages/_pynvml_redirector.pth
+++ b/site-packages/_pynvml_redirector.pth
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-License-Identifier: BSD-3-Clause
 
 import _pynvml_redirector

--- a/site-packages/_pynvml_redirector.py
+++ b/site-packages/_pynvml_redirector.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-License-Identifier: BSD-3-Clause
 
 import importlib
 import importlib.abc

--- a/site-packages/_pynvml_redirector.py
+++ b/site-packages/_pynvml_redirector.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import importlib
+import importlib.abc
+import sys
+import warnings
+
+import_msg = (
+    "The pynvml package is deprecated. Please install nvidia-ml-py instead. "
+    "If you did not install pynvml directly, please report this to the maintainers of "
+    "the package that installed pynvml for you."
+)
+
+
+class PynvmlFinder(importlib.abc.MetaPathFinder):
+    def __init__(self):
+        self.has_warned = False
+
+    def find_spec(self, name, path, target=None):
+        if name.startswith("pynvml") and not self.has_warned:
+            warnings.warn(import_msg, FutureWarning, stacklevel=2)
+            self.has_warned = True
+            for finder in sys.meta_path:
+                try:
+                    spec = finder.find_spec(name, path, target)
+                except AttributeError:
+                    # Finders written to a pre-Python 3.4 spec for finders will
+                    # not implement find_spec. We can skip those altogether.
+                    continue
+                else:
+                    if spec is not None:
+                        return spec
+
+
+finder = PynvmlFinder()
+sys.meta_path.insert(0, finder)

--- a/site-packages/_pynvml_redirector.py
+++ b/site-packages/_pynvml_redirector.py
@@ -6,31 +6,33 @@ import importlib.abc
 import sys
 import warnings
 
-import_msg = (
+PYNVML_MSG = (
     "The pynvml package is deprecated. Please install nvidia-ml-py instead. "
     "If you did not install pynvml directly, please report this to the maintainers of "
     "the package that installed pynvml for you."
 )
 
 
+PYNVML_UTILS_MSG = (
+    "The pynvml_utils module is deprecated. The source will remain accessible on "
+    "Github at https://github.com/gpuopenanalytics/pynvml/."
+)
+
+
 class PynvmlFinder(importlib.abc.MetaPathFinder):
     def __init__(self):
-        self.has_warned = False
+        self.has_warned_pynvml = False
+        self.has_warned_pynvml_utils = False
 
-    def find_spec(self, name, path, target=None):
-        if name.startswith("pynvml") and not self.has_warned:
-            warnings.warn(import_msg, FutureWarning, stacklevel=2)
-            self.has_warned = True
-            for finder in sys.meta_path:
-                try:
-                    spec = finder.find_spec(name, path, target)
-                except AttributeError:
-                    # Finders written to a pre-Python 3.4 spec for finders will
-                    # not implement find_spec. We can skip those altogether.
-                    continue
-                else:
-                    if spec is not None:
-                        return spec
+    def find_spec(self, name, _, __=None):
+        if name.startswith("pynvml") and not self.has_warned_pynvml:
+            warnings.warn(PYNVML_MSG, FutureWarning, stacklevel=2)
+            self.has_warned_pynvml = True
+
+        if name.startswith("pynvml_utils") and not self.has_warned_pynvml_utils:
+            warnings.warn(PYNVML_UTILS_MSG, FutureWarning, stacklevel=2)
+            self.has_warned_pynvml_utils = True
+        # Defer actually finding the module to the other finders
 
 
 finder = PynvmlFinder()


### PR DESCRIPTION
This PR adds deprecation warnings to pynvml and pynvml_utils indicating that these packages are going away. For pynvml_utils we could use a simpler approach of just throwing the warning inside the package's `__init__.py` file, but for `pynvml` we have to use the pth approach since it's just a metapackage relying on nvidia-ml-py for all its code, so we may as well reuse the finder's `find_spec` method for both warnings.